### PR TITLE
[TALEARNT-151] 회원가입 완료 마크업 / SignUp complete markup

### DIFF
--- a/src/common/common.type.ts
+++ b/src/common/common.type.ts
@@ -7,7 +7,7 @@ export type CustomVariantProps<
 };
 
 export type CommonIconProps = ComponentProps<"svg"> & {
-  scale?: number;
+  size?: number;
 };
 
 export type responseDataType<T> = {

--- a/src/components/icons/CaretIcon/CaretIcon.tsx
+++ b/src/components/icons/CaretIcon/CaretIcon.tsx
@@ -30,22 +30,20 @@ const caretIconVariants = cva<CaretIconVariantsType>("", {
  * 꼬리 없는 화살표 아이콘
  * 색 변경은 className에 "stroke-talearnt-gray-500" 와 같이 넣어주면 됨
  * direction은 화살표가 가르킬 방향
- * size 변경은 scale에 배수를 넣어주면 됨
+ * size 변경은 원하는 size를 넣어주면 됨
  *
  * @param {string | undefined} className
  * @param {"top" | "right" | "bottom" | "left"} direction
- * @param {number | undefined} scale
+ * @param {number | undefined} size
  * @param {Omit<CaretIconProps, "scale" | "className" | "direction">} props
  * @constructor
  */
 function CaretIcon({
   className,
   direction,
-  scale = 1,
+  size = 24,
   ...props
 }: CaretIconProps) {
-  const size = scale * 24;
-
   return (
     <svg
       width={size}

--- a/src/components/icons/CircleCaretIcon/CircleCaretIcon.tsx
+++ b/src/components/icons/CircleCaretIcon/CircleCaretIcon.tsx
@@ -30,22 +30,20 @@ const circleCaretIconVariants = cva<CircleCaretIconVariantsType>("", {
  * 동그란 화살표 아이콘
  * 색 변경은 className에 "stroke-talearnt-gray-500" 와 같이 넣어주면 됨
  * direction은 화살표가 가르킬 방향
- * size 변경은 scale에 배수를 넣어주면 됨
+ * size 변경은 원하는 size를 넣어주면 됨
  *
  * @param {string | undefined} className
  * @param {"top" | "right" | "bottom" | "left"} direction
- * @param {number | undefined} scale
+ * @param {number | undefined} size
  * @param {Omit<CaretIconProps, "scale" | "className" | "direction">} props
  * @constructor
  */
 function CircleCaretIcon({
   className,
   direction,
-  scale = 1,
+  size = 30,
   ...props
 }: CircleCaretIconProps) {
-  const size = scale * 30;
-
   return (
     <svg
       width={size}

--- a/src/components/icons/CircleCheckIcon/CircleCheckIcon.tsx
+++ b/src/components/icons/CircleCheckIcon/CircleCheckIcon.tsx
@@ -4,16 +4,14 @@ import { CommonIconProps } from "@common/common.type";
 
 /**
  * 동그란 체크 아이콘
- * size 변경은 scale에 배수를 넣어주면 됨
+ * size 변경은 원하는 size를 넣어주면 됨
  *
  * @param {string | undefined} className
- * @param {number | undefined} scale
+ * @param {number | undefined} size
  * @param {Omit<CommonIconProps, "scale" | "className">} props
  * @constructor
  */
-function CircleCheckIcon({ className, scale = 1, ...props }: CommonIconProps) {
-  const size = scale * 24;
-
+function CircleCheckIcon({ className, size = 24, ...props }: CommonIconProps) {
   return (
     <svg
       width={size}

--- a/src/components/icons/ErrorIcon/ErrorIcon.tsx
+++ b/src/components/icons/ErrorIcon/ErrorIcon.tsx
@@ -5,17 +5,15 @@ import { CommonIconProps } from "@common/common.type";
 /**
  * 에러 아이콘
  * 색 변경은 className에 "fill-talearnt-Error_01" 와 같이 넣어주면 됨
- * size 변경은 scale에 배수를 넣어주면 됨
+ * size 변경은 원하는 size를 넣어주면 됨
  *
  * @param {string | undefined} className
- * @param {number | undefined} scale
+ * @param {number | undefined} size
  * @param {Omit<CommonIconProps, "scale" | "className">} props
  * @constructor
  */
 
-function ErrorIcon({ className, scale = 1, ...props }: CommonIconProps) {
-  const size = scale * 14;
-
+function ErrorIcon({ className, size = 14, ...props }: CommonIconProps) {
   return (
     <svg
       width={size}

--- a/src/components/icons/NotificationIcon/NotificationIcon.tsx
+++ b/src/components/icons/NotificationIcon/NotificationIcon.tsx
@@ -4,17 +4,15 @@ import { CommonIconProps } from "@common/common.type";
 
 /**
  * 알림 아이콘
- * size 변경은 scale에 배수를 넣어주면 됨
+ * size 변경은 원하는 size를 넣어주면 됨
  *
  * @param {string | undefined} className
- * @param {number | undefined} scale
+ * @param {number | undefined} size
  * @param {Omit<CommonIconProps, "scale" | "className">} props
  * @constructor
  */
 
-function NotificationIcon({ className, scale = 1, ...props }: CommonIconProps) {
-  const size = scale * 24;
-
+function NotificationIcon({ className, size = 24, ...props }: CommonIconProps) {
   return (
     <svg
       width={size}

--- a/src/components/icons/SearchIcon/SearchIcon.tsx
+++ b/src/components/icons/SearchIcon/SearchIcon.tsx
@@ -5,18 +5,15 @@ import { CommonIconProps } from "@common/common.type";
 /**
  * 돋보기 아이콘
  * 색 변경은 className에 "stroke-talearnt-gray-500" 와 같이 넣어주면 됨
- * size 변경은 scale에 배수를 넣어주면 됨
+ * size 변경은 원하는 size를 넣어주면 됨
  *
  * @param {string | undefined} className
- * @param {number | undefined} scale
+ * @param {number | undefined} size
  * @param {Omit<CommonIconProps, "scale" | "className">} props
- * @returns {JSX.Element}
  * @constructor
  */
 
-function SearchIcon({ className, scale = 1, ...props }: CommonIconProps) {
-  const size = scale * 24;
-
+function SearchIcon({ className, size = 24, ...props }: CommonIconProps) {
   return (
     <svg
       width={size}

--- a/src/layout/MainLayout/MainLayout.tsx
+++ b/src/layout/MainLayout/MainLayout.tsx
@@ -18,7 +18,7 @@ function MainLayout() {
         <LogoIcon className={"cursor-pointer"} onClick={() => navigator("/")} />
         <Input
           className={"h-10 rounded-full border-talearnt-Primary_01 pr-[55px]"}
-          wrapperClassName={"w-[31.25rem]"}
+          wrapperClassName={"w-[31.25rem] relative"}
         >
           <SearchIcon className={"absolute right-4 top-2 cursor-pointer"} />
         </Input>

--- a/src/pages/auth/SignIn/SignIn.tsx
+++ b/src/pages/auth/SignIn/SignIn.tsx
@@ -13,7 +13,7 @@ import { Input } from "@components/Input/Input";
 import { apiErrorType } from "@common/common.type";
 import { accountType } from "@pages/auth/api/auth.type";
 
-const loginSchema = object({
+const signInSchema = object({
   userId: string().required("이메일을 입력해 주세요"),
   pw: string().required("비밀번호를 입력해 주세요")
 }).required();
@@ -27,7 +27,7 @@ function SignIn() {
     register,
     setError
   } = useForm<accountType>({
-    resolver: yupResolver(loginSchema)
+    resolver: yupResolver(signInSchema)
   });
 
   const onSubmit = async (data: accountType) => {

--- a/src/pages/auth/SignUp/components/CompleteSignUp/CompleteSignUp.tsx
+++ b/src/pages/auth/SignUp/components/CompleteSignUp/CompleteSignUp.tsx
@@ -1,0 +1,23 @@
+import { classNames } from "@utils/classNames";
+
+import { CircleCheckIcon } from "@components/icons/CircleCheckIcon/CircleCheckIcon";
+
+function CompleteSignUp() {
+  return (
+    <div className={"flex flex-col items-center gap-8"}>
+      <CircleCheckIcon className={"stroke-talearnt-Primary_01"} size={70} />
+      <p
+        className={classNames(
+          "flex items-center justify-center",
+          "rounded-xl border border-talearnt-Line_01",
+          "h-[5.25rem] w-full bg-talearnt-BG_Up_01",
+          "font-medium"
+        )}
+      >
+        로그인하시면 더욱 다양한 서비스를 제공 받으실 수 있습니다.
+      </p>
+    </div>
+  );
+}
+
+export { CompleteSignUp };

--- a/src/pages/auth/SignUp/components/StepFormContainer/StepFormContainer.tsx
+++ b/src/pages/auth/SignUp/components/StepFormContainer/StepFormContainer.tsx
@@ -7,6 +7,7 @@ import { classNames } from "@utils/classNames";
 import { Button } from "@components/Button/Button";
 import { Stepper } from "@components/Stepper/Stepper";
 import { Agreements } from "@pages/auth/SignUp/components/Agreements/Agreements";
+import { CompleteSignUp } from "@pages/auth/SignUp/components/CompleteSignUp/CompleteSignUp";
 import { SignUpFields } from "@pages/auth/SignUp/components/SignupFields/SignUpFields/SignUpFields";
 
 const stepArray = ["약관 동의", "정보 입력", "가입 완료"];
@@ -38,7 +39,13 @@ function StepFormContainer() {
   const agreement0 = watch("agreement0");
   const agreement1 = watch("agreement1");
 
-  const handleCTAOnClick = () => setStep(prev => prev + 1);
+  const handleCTAOnClick = () => {
+    if (step < 3) {
+      setStep(prev => prev + 1);
+    } else {
+      navigator("/sign-in");
+    }
+  };
 
   return (
     <div
@@ -54,6 +61,7 @@ function StepFormContainer() {
       </p>
       {step === 1 && <Agreements />}
       {step === 2 && <SignUpFields />}
+      {step === 3 && <CompleteSignUp />}
       <div
         className={classNames(
           "mt-[3.5rem] grid grid-rows-[3.125rem] gap-[1.975rem]",


### PR DESCRIPTION
### 설명 / Description
회원가입이 완료되었을 때 마크업을 추가/적용했습니다.
commonIconType 에서 아이콘의 사이즈 변경시 scale을 사용하도록 했었는데 원하는 size를 입력받는 것이 더 편리해보여 수정했습니다.

Sign up complete design add/apply
In commonIconType, I previously used scale to adjust icon sizes, but I’ve updated it to accept a specific size input for greater convenience.
### 이슈 티켓 / Related Issues
[TALEARNT-151](https://jin02014.atlassian.net/browse/TALEARNT-151?atlOrigin=eyJpIjoiYmY1OTM0MWRiYWMxNDgzMDhiN2FlN2RhY2FlM2Q0ZDciLCJwIjoiaiJ9)

### 변경 사항 / Changes Made
- CompleteSignUp 컴포넌트 추가 / Make CompleteSignUp component
- commonIconType 변경 / Change commonIconType

### 체크리스트 / Checklist
- [x] 모든 테스트가 통과합니까? / Does it pass all tests?

### 스크린샷 / Screenshots

### 추가 메모 / Additional Notes


[TALEARNT-151]: https://jin02014.atlassian.net/browse/TALEARNT-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ