### PR TITLE
[TALEARNT-277] 1분 내 인증번호 전송 5회 초과시 10분간 정지 기능 추가 | Restrict sending verification codes for 10 minutes if exceeded 5 attempts within 1 minute

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -4,7 +4,7 @@ import { useToastStore } from "@common/common.store";
 
 function Toast() {
   const { toastList } = useToastStore();
-  console.log(toastList);
+
   return (
     <div
       className={classNames(

--- a/src/components/icons/NotificationIcon/NotificationIcon.tsx
+++ b/src/components/icons/NotificationIcon/NotificationIcon.tsx
@@ -20,12 +20,11 @@ function NotificationIcon({ className, size = 24, ...props }: CommonIconProps) {
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={classNames(className)}
+      className={classNames("stroke-talearnt-Text_02", className)}
       {...props}
     >
       <path
         d="M9 20.9899C9.79613 21.618 10.8475 22 12 22C13.1525 22 14.2039 21.618 15 20.9899M3.57109 17.7575C3.09677 17.7575 2.83186 17.0216 3.11877 16.6127C3.78453 15.6639 4.42712 14.2724 4.42712 12.5967L4.45458 10.1685C4.45458 5.65717 7.83278 2 12 2C16.2286 2 19.6566 5.71104 19.6566 10.2888L19.6291 12.5967C19.6291 14.2839 20.2495 15.683 20.8882 16.6322C21.164 17.0421 20.8984 17.7575 20.43 17.7575H3.57109Z"
-        stroke="stroke-talearnt-gray-800"
         strokeWidth="1.4"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/src/layout/MainLayout/MainLayout.tsx
+++ b/src/layout/MainLayout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link, Outlet, useNavigate } from "react-router-dom";
 
 import { getAccessTokenUseRefreshToken } from "@pages/auth/auth.api";
@@ -10,10 +10,26 @@ import { useAuthStore } from "@pages/auth/auth.store";
 
 import { Button } from "@components/Button/Button";
 import { LogoIcon } from "@components/icons/LogoIcon/LogoIcon";
+import { NotificationIcon } from "@components/icons/NotificationIcon/NotificationIcon";
 import { SearchIcon } from "@components/icons/SearchIcon/SearchIcon";
 import { Input } from "@components/Input/Input";
 import { Prompt } from "@components/Prompt/Prompt";
 import { Toast } from "@components/Toast/Toast";
+
+const linkArray = [
+  {
+    path: "talent",
+    content: "재능교환"
+  },
+  {
+    path: "community",
+    content: "커뮤니티"
+  },
+  {
+    path: "sign-up/agreements",
+    content: "회원가입"
+  }
+];
 
 function MainLayout() {
   const navigator = useNavigate();
@@ -21,64 +37,107 @@ function MainLayout() {
   const { accessToken, setAccessToken } = useAuthStore();
   const { promptData } = usePromptStore();
 
+  const [isLoading, setIsLoading] = useState(true);
+
   useEffect(() => {
     if (accessToken === null) {
       getAccessTokenUseRefreshToken()
         .then(({ data }) => {
           setAccessToken(data.accessToken);
         })
-        .catch((error: unknown) =>
-          console.error("Token refresh failed", error)
-        );
+        .catch((error: unknown) => console.error("Token refresh failed", error))
+        .finally(() => setIsLoading(false));
     }
   }, [accessToken, setAccessToken]);
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <>
       <header
         className={classNames(
-          "flex items-center justify-center",
-          "shadow-[inset_0_-1px_0_0] shadow-talearnt-Line_01",
+          "flex items-center justify-between",
+          "px-[80px] shadow-[inset_0_-1px_0_0] shadow-talearnt-Line_01",
           "h-[98px]"
         )}
       >
-        <LogoIcon
-          className={classNames("mr-[40px]", "cursor-pointer")}
-          onClick={() => navigator("/")}
-        />
-        <Input
-          className={classNames(
-            "rounded-full border-talearnt-Primary_01 pr-[55px]",
-            "h-[50px]"
-          )}
-          placeholder={"관심있는 재능 키워드를 입력해 주세요."}
-          wrapperClassName={classNames("relative", "w-[31.25rem] mr-[358px]")}
-        >
-          <SearchIcon
-            className={classNames(
-              "absolute right-4 top-[10px]",
-              "cursor-pointer"
-            )}
+        <div className={"flex gap-10"}>
+          <LogoIcon
+            className={classNames("cursor-pointer")}
+            onClick={() => navigator("/")}
           />
-        </Input>
-        <div className={classNames("flex items-center gap-[8px]", "h-[40px]")}>
-          <Link
+          <Input
             className={classNames(
-              "flex items-center justify-center",
-              "h-[40px] w-[94px]",
-              "text-lg font-medium text-talearnt-Text_02"
+              "rounded-full border-talearnt-Primary_01 pr-[55px]",
+              "h-[50px]"
             )}
-            to={"sign-up/agreements"}
+            placeholder={"관심있는 재능 키워드를 입력해 주세요."}
+            wrapperClassName={classNames("relative", "w-[477px]")}
           >
-            회원가입
-          </Link>
-          <Button
-            buttonStyle={"outlined"}
-            className={classNames("h-[40px] w-[110px]", "text-lg")}
-            onClick={() => navigator("sign-in")}
-          >
-            로그인
-          </Button>
+            <SearchIcon
+              className={classNames(
+                "absolute right-4 top-[10px]",
+                "cursor-pointer"
+              )}
+            />
+          </Input>
+        </div>
+        <div className={"flex items-center gap-6"}>
+          <div className={classNames("flex items-center gap-2", "h-[40px]")}>
+            {linkArray.map(({ path, content }) => {
+              if (content === "회원가입" && accessToken) {
+                return;
+              }
+
+              return (
+                <Link
+                  className={classNames(
+                    "flex items-center justify-center",
+                    "h-[40px] w-[94px]",
+                    "text-lg font-medium text-talearnt-Text_02"
+                  )}
+                  to={path}
+                  key={path}
+                >
+                  {content}
+                </Link>
+              );
+            })}
+            <Button
+              buttonStyle={"outlined"}
+              className={classNames("h-[40px] w-[110px]", "text-lg")}
+              onClick={() => navigator(accessToken ? "" : "sign-in")}
+            >
+              {accessToken ? "글쓰기" : "로그인"}
+            </Button>
+          </div>
+          {accessToken && (
+            <>
+              <NotificationIcon />
+              <div className={"flex items-center"}>
+                <div
+                  className={classNames(
+                    "rounded-full border border-talearnt-Icon_02 bg-talearnt-BG_Up_02",
+                    "h-8 w-8"
+                  )}
+                />
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M4.60482 5.69531H11.3952C11.5153 5.69582 11.6326 5.73193 11.7322 5.79908C11.8318 5.86623 11.9092 5.96141 11.9547 6.07258C12.0002 6.18374 12.0118 6.30591 11.9878 6.42362C11.9639 6.54134 11.9056 6.64932 11.8203 6.73391L8.43123 10.123C8.37477 10.1799 8.30759 10.2251 8.23358 10.256C8.15957 10.2868 8.08018 10.3027 8 10.3027C7.91982 10.3027 7.84043 10.2868 7.76642 10.256C7.69241 10.2251 7.62523 10.1799 7.56877 10.123L4.17966 6.73391C4.09438 6.64932 4.03609 6.54134 4.01217 6.42362C3.98824 6.30591 3.99977 6.18374 4.04527 6.07258C4.09078 5.96141 4.16823 5.86623 4.26783 5.79908C4.36743 5.73193 4.4847 5.69582 4.60482 5.69531Z"
+                    fill="#414A4E"
+                  />
+                </svg>
+              </div>
+            </>
+          )}
         </div>
       </header>
       <main

--- a/src/pages/auth/SignUp/components/InfoFields/InfoFields.tsx
+++ b/src/pages/auth/SignUp/components/InfoFields/InfoFields.tsx
@@ -87,7 +87,7 @@ function InfoFields() {
   const { setToast } = useToastStore();
   const { setPrompt } = usePromptStore();
 
-  const [canProceed, setCanProceed] = useState(true);
+  const [canProceed, setCanProceed] = useState(false);
   const [verification, setVerification] = useState<verificationStateType>({
     isCodeVerified: false
   });


### PR DESCRIPTION
### 설명 / Description
1분 내 인증번호 전송 5회 초과시 비정상 동작으로 간주하여 10분간 인증번호 전송을 차단합니다.
백엔드에서도 차단을 하지만 불필요한 API 요청을 방지하기 위해 프론트에서도 차단하도록 합니다.

If the verification code is sent more than 5 times within 1 minute, it will be considered abnormal behavior, and the verification code sending will be blocked for 10 minutes.
While blocking will be implemented on the backend, it will also be blocked on the frontend to prevent unnecessary API requests.

### 이슈 티켓 / Related Issues
[TALEARNT-277](https://jin02014.atlassian.net/browse/TALEARNT-277?atlOrigin=eyJpIjoiNzZkNGVhYjYxNzdlNGM4NWExOTY5N2NkZmU5Njg0MGYiLCJwIjoiaiJ9)

### 변경 사항 / Changes Made
- 

### 체크리스트 / Checklist
- [ ] 모든 테스트가 통과합니까? / Does it pass all tests?

### 스크린샷 / Screenshots

### 추가 메모 / Additional Notes


[TALEARNT-277]: https://jin02014.atlassian.net/browse/TALEARNT-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ