### PR TITLE
[FEAT] 카카오 계정 중복인 경우 에러 핸들링 | Error handling for duplicate Kakao acco…

### DIFF
--- a/src/pages/auth/Kakao/KakaoOauth/KakaoOauth.tsx
+++ b/src/pages/auth/Kakao/KakaoOauth/KakaoOauth.tsx
@@ -3,6 +3,8 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { getKakaoAccessToken } from "@pages/auth/auth.api";
 
+import { checkObjectType } from "@utils/checkObjectType";
+
 import { usePromptStore } from "@common/common.store";
 import {
   useAuthStore,
@@ -34,11 +36,24 @@ function KakaoOauth() {
           navigator("/kakao/info-fields");
         }
       })
-      .catch(() => {
-        setPrompt({
-          title: "카카오 연동 실패",
-          content: "카카오로부터 연동이 실패하였습니다."
-        });
+      .catch((error: unknown) => {
+        if (
+          checkObjectType(error) &&
+          "errorCode" in error &&
+          error.errorCode === "409-USER-17"
+        ) {
+          setPrompt({
+            title: "가입된 회원 정보",
+            content:
+              "이미 가입된 계정이 있습니다. 기존 아이디로 로그인 해주세요."
+          });
+        } else {
+          setPrompt({
+            title: "카카오 연동 실패",
+            content: "카카오로부터 연동이 실패하였습니다."
+          });
+        }
+
         navigator("/sign-in");
       });
   }, [code, navigator, setAccessToken, setPrompt, setResponse]);


### PR DESCRIPTION
### 설명 / Description
카카오 계정이 자체 회원가입한 계정과 휴대폰 번호가 중복인 경우의 에러 핸들링을 추가합니다.
Add error handling for cases where a Kakao account is duplicated with an already registered account or phone number.

### 이슈 티켓 / Related Issues
[TALEARNT-103](https://jin02014.atlassian.net/browse/TALEARNT-103?atlOrigin=eyJpIjoiZDk1ODkzMzc0OWQzNGU4ZjhjMDMyMTBkYWU1MWU2MzkiLCJwIjoiaiJ9)

### 변경 사항 / Changes Made
- 카카오 Auth 에러 핸들링 추가 | Add error handling Kakao Auth

### 체크리스트 / Checklist
- [ ] 모든 테스트가 통과합니까? / Does it pass all tests?

### 스크린샷 / Screenshots

### 추가 메모 / Additional Notes


[TALEARNT-103]: https://jin02014.atlassian.net/browse/TALEARNT-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ